### PR TITLE
Fix and somewhat refurbish CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [pull_request, push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:
@@ -9,18 +13,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        resolver: [nightly, lts-15, lts-14, lts-12, lts-11, lts-9]
+        os: [ubuntu-latest]
+        resolver: [nightly, lts-23, lts-22, lts-21, lts-20, lts-19, lts-18, lts-16, lts-14, lts-12]
+        include:
+          - os: macos-latest
+            resolver: nightly
+          - os: windows-latest
+            resolver: nightly
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        if:   runner.os != 'Windows'
+        uses: actions/cache@v4
         with:
+          # This path does not work under Windows:
           path: ~/.stack
-          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.resolver }}-
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-14.17
+resolver: lts-21.25


### PR DESCRIPTION
- Update action versions
- Update list of LTSs to test with (dropping the ones no longer supported by stack)
- Limit macOS and Windows builds to nightly
- Improve cache key
- Switch off defunct caching for Windows